### PR TITLE
GV.hの修正

### DIFF
--- a/include/GV.h
+++ b/include/GV.h
@@ -7,9 +7,6 @@
 #include <ncurses.h>
 #include <locale.h>
 
-#include <ncurses.h>
-#include <locale.h>
-
 #include "data.h" // データ構造関連
 #include "dice.h" // 六面ダイス関連
 #include "curses_init.h" // ncurses関連


### PR DESCRIPTION
# 概要
- マージしたときに出たゴミを消します．
# 修正前
- gv.hに二重Includeが存在する(コンパイルでは怒られはしない)．
# 修正後
- アホ(マージした私)が出した二重Includeを解消．
