### PR TITLE
makefileを直そう(2回目)

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,28 @@
+CC      = gcc
+CFLAGS  =
+LDFLAGS =
+LIBS    =
+INCLUDE = -I./include -I/usr/include/ncurses
+SRC_DIR = ./source
+OBJ_DIR = ./build
+SOURCES = $(shell ls $(SRC_DIR)/*.c)
+OBJS    = $(subst $(SRC_DIR),$(OBJ_DIR), $(SOURCES:.c=.o))
+TARGET  = Africa
+DEPENDS = $(OBJS:.o=.d)
+OPTION = -lncurses
+
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS) $(LIBS)
+	$(CC) -o $@ $(OBJS) $(OPTION) $(LDFLAGS)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
+
+clean:
+	$(RM) $(OBJS) $(TARGET) $(DEPENDS)
+
+-include $(DEPENDS)
+
+.PHONY: all clean

--- a/makefile
+++ b/makefile
@@ -34,6 +34,10 @@ $(TARGET): $(OBJS) $(LIBS)
 
 #オブジェクトファイルを結合
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+#buildフォルダがなかったら自動生成
+	@if [ ! -d $(OBJ_DIR) ]; \
+		then echo "mkdir -p $(OBJ_DIR)"; mkdir -p $(OBJ_DIR); \
+		fi
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 #削除時の指定コマンド オブジェクトファイル系を全て削除

--- a/makefile
+++ b/makefile
@@ -33,8 +33,9 @@ $(TARGET): $(OBJS) $(LIBS)
 	$(CC) -o $@ $(OBJS) $(OPTION) $(LDFLAGS)
 
 #オブジェクトファイルを結合
+#@ifの固まりはbuildフォルダがなかったら自動生成
+
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
-#buildフォルダがなかったら自動生成
 	@if [ ! -d $(OBJ_DIR) ]; \
 		then echo "mkdir -p $(OBJ_DIR)"; mkdir -p $(OBJ_DIR); \
 		fi

--- a/makefile
+++ b/makefile
@@ -1,25 +1,42 @@
+#もっと細かい説明がほしいのであればここにhttp://urin.github.io/posts/2013/simple-makefile-for-clang/
+
+#コンパイラの指定 空欄でcc
 CC      = gcc
+#コンパイラオプション指定
 CFLAGS  =
+#リンクオプション指定
 LDFLAGS =
+#ライブラリの指定
 LIBS    =
+#インクルード系の指定 ここではローカルパスとwindowsようにncursesのパスを別に指定
 INCLUDE = -I./include -I/usr/include/ncurses
+#ソースコードフォルダの指定
 SRC_DIR = ./source
+#オブジェクトフォルダの指定 .oファイルをここに置く
 OBJ_DIR = ./build
+#ソースファイルの指定 lsコマンドを使用して.cファイル全てを指定
 SOURCES = $(shell ls $(SRC_DIR)/*.c)
+#オブジェクトの指定 SOURCESをそのまま.oにする
 OBJS    = $(subst $(SRC_DIR),$(OBJ_DIR), $(SOURCES:.c=.o))
+#ターゲット名の指定
 TARGET  = Africa
+#依存関係ファイル指定
 DEPENDS = $(OBJS:.o=.d)
+#オプション指定 ここではncursesコマンドを入力
 OPTION = -lncurses
 
 
 all: $(TARGET)
 
+#オブジェクトファイルを結合
 $(TARGET): $(OBJS) $(LIBS)
 	$(CC) -o $@ $(OBJS) $(OPTION) $(LDFLAGS)
 
+#オブジェクトファイルを結合
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
+#削除時の指定コマンド オブジェクトファイル系を全て削除
 clean:
 	$(RM) $(OBJS) $(TARGET) $(DEPENDS)
 


### PR DESCRIPTION
# 概要
* ソースファイルが増えた時にいちいちmakefileを増やすの面倒だなを解決したいなって

# 変更前
* いちいちmakefileを書き換える必要がある．
* オブジェクトファイルがソースフォルダに生成される．
* 各ファイルで"../include/~.h"てやってた．
* windows用のncurses.hのパスに対応してなかった．
* コンパイルにcc使ってた？(ように見えた)

# 変更後
* いろいろ調べたけどよくわからなかったので某所からmakefileをパクりました．
* 分かる範囲でコメント付しました．
* ソースフォルダに入ってる.cファイル全部コンパイルしてくれます．
* "~.h"ってインクルードしても動きます．
* windows用のncurses.hのパスに対応．
* コンパイルに一応gcc使いました．